### PR TITLE
Don't use -hot and HotModuleReplacementPlugin at the same time.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -121,8 +121,6 @@ function createRenderConfig(isDev) {
                 ]
             }),
 
-            new webpack.HotModuleReplacementPlugin(),
-
         ],
 
         devServer: isDev ? {


### PR DESCRIPTION
It causes a Maximum call stack size exceeded error:
![2020-08-11 at 2 12 PM](https://user-images.githubusercontent.com/2669/89949398-b4278b80-dbdc-11ea-8323-07b83264e8a8.png)
