### PR TITLE
Use electron-renderer target

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ function createRenderConfig(isDev) {
 
         context: path.join(__dirname, "src"),
 
-        target: "web", // any other target value makes react-hot-loader stop working
+        target: "electron-renderer",
 
         resolve: {
             extensions: [".js", ".jsx", ".ts", ".tsx", ".json"]


### PR DESCRIPTION
You can use the electron-renderer target. See https://github.com/marceloaugusto80/electron-react-typescript-boilerplate/pull/6 for a hot reload fix.